### PR TITLE
Support literal values as code

### DIFF
--- a/lib/formular.ex
+++ b/lib/formular.ex
@@ -418,7 +418,7 @@ defmodule Formular do
   def compile_to_module!(code, mod, context) when is_binary(code),
     do: code |> Code.string_to_quoted!() |> compile_to_module!(mod, context)
 
-  def compile_to_module!({_, _, _} = ast, mod, context) do
+  def compile_to_module!(ast, mod, context) do
     with :ok <- valid?(ast) do
       env = %Macro.Env{
         functions: imported_functions(context),

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -2,4 +2,21 @@ defmodule Formular.CompilerTest do
   use ExUnit.Case, async: true
 
   doctest Formular.Compiler
+
+  describe "literal code support" do
+    test "it supports atoms" do
+      {:module, _} = Formular.compile_to_module!(":ok", :ok_module)
+      assert Formular.eval({:module, :ok_module}, []) == {:ok, :ok}
+    end
+
+    test "it supports tuples" do
+      {:module, _} = Formular.compile_to_module!("{:ok, :tuple}", :literal_tuple)
+      assert Formular.eval({:module, :literal_tuple}, []) == {:ok, {:ok, :tuple}}
+    end
+
+    test "it supports numbers" do
+      {:module, _} = Formular.compile_to_module!("3.14", :literal_number)
+      assert Formular.eval({:module, :literal_number}, []) == {:ok, 3.14}
+    end
+  end
 end


### PR DESCRIPTION
Now code to compile can be a literal value, e.g.

```elixir
iex> Formular.compile_to_module("123", :my_module)
{:module, :my_module}
```